### PR TITLE
Translate task timeout exits to errors to retain plugged conn

### DIFF
--- a/lib/absinthe/plug.ex
+++ b/lib/absinthe/plug.ex
@@ -320,6 +320,10 @@ defmodule Absinthe.Plug do
           |> encode(500, error_result(error), config)
       end
     catch
+      :exit, {:timeout, _} = reason ->
+        stack = __STACKTRACE__
+        Plug.Conn.WrapperError.reraise(conn, :error, reason, stack)
+
       kind, reason ->
         stack = __STACKTRACE__
         Plug.Conn.WrapperError.reraise(conn, kind, reason, stack)


### PR DESCRIPTION
So here’s the problem I’m with Bottler error-tracking:

- The vast majority of our errors are task timeouts. When a task times out, it throws an `:exit` signal. There is no option to raise an error here. https://github.com/absinthe-graphql/absinthe/blob/master/lib/absinthe/middleware/async.ex#L86
- With the changes I made recently, that `:exit` is caught by `absinthe-plug` and wrapped in a `Plug.Conn.WrapperError`, _but_, because `:exit` is not `:error`, the `conn` isn’t wrapped in the error and important context is lost. Importantly, the `conn` has callbacks attached with are necessary to close the trace at the end of the request. 
   -   Here's where the `:exit` is caught and re-raised: https://github.com/wistia/absinthe_plug/blob/master/lib/absinthe/plug.ex#L325 
   -  Here's where you can see that only `:error`s wrap the conn: https://github.com/elixir-plug/plug/blob/main/lib/plug/conn/wrapper_error.ex

These two places--where the task is awaited and where `absinthe-plug` catches the `:exit` are afaict the only places we can do something about it. So we've got two choices:

1. Move to a fork of absinthe, and apply one of the patches mentioned in the issue @blatyo opened 1.5 years ago: https://github.com/absinthe-graphql/absinthe/issues/1117
2. Pretend that timeout exit signals caught by this plug are actually errors. Which, like, they are, for all intents and purposes--if a task times out, the user will see a 500.

Since we already have this fork anyway, and since this plug does relatively light lifting as compared to `absinthe` itself, I think we should just do this.